### PR TITLE
Website changes sam

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -75,7 +75,7 @@ export default function Hero() {
         {SITE_DESCRIPTION}
       </h2>
       <div className={cn(styleUtils.appear, styleUtils['appear-third'], styles.info)}>
-        <p>CSU Fullerton's premire hackathon!</p>
+        <p>CSU Fullerton's premiere hackathon!</p>
         {/* <p>{DATE}</p>
         <div className={styles['description-separator']}>•</div>
         <p>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -22,7 +22,7 @@ import Tree from './illustrations/tree';
 import TuffyTent from './illustrations/tuffy-tent';
 import styleUtils from './utils.module.css';
 import styles from './hero.module.css';
-import { BRAND_NAME, LEAF_COLORS, SITE_DESCRIPTION, SPONSORSHIP } from '@lib/constants';
+import { BRAND_NAME, LEAF_COLORS, SITE_DESCRIPTION, EMAIL } from '@lib/constants';
 
 export default function Hero() {
   return (
@@ -75,7 +75,7 @@ export default function Hero() {
         {SITE_DESCRIPTION}
       </h2>
       <div className={cn(styleUtils.appear, styleUtils['appear-third'], styles.info)}>
-        <p>Join the TuffyHacks 2022 organizer team!</p>
+        <p>CSU Fullerton's premire hackathon!</p>
         {/* <p>{DATE}</p>
         <div className={styles['description-separator']}>•</div>
         <p>
@@ -90,12 +90,12 @@ export default function Hero() {
         )}
       >
         <CallToAction
-          text="Organizer Application"
-          link="https://forms.gle/CzL3yV1NEmEVcx1fA"
-          // disabled={true}
-          // classes={[styleUtils.disabled]}
+          text="Stay up to Date"
+          link="https://instagram.com/tuffyhacks"
+        // disabled={true}
+        // classes={[styleUtils.disabled]}
         />
-        <CallToAction text="Sponsor 2022" link={SPONSORSHIP} />
+        <CallToAction text="Sponsor Us" link={EMAIL} />
       </div>
     </section>
   );

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -46,7 +46,7 @@ export default function Layout({ children, className, hideNav, layoutStyles }: P
                 <a className={styles.logo}>TuffyHacks</a>
               </Link>
             </div>
-            <div className={styles.tabs}>
+            {/* <div className={styles.tabs}>
               {NAVIGATION.map(({ name, route }) => (
                 <Link key={name} href={route}>
                   <a
@@ -58,7 +58,7 @@ export default function Layout({ children, className, hideNav, layoutStyles }: P
                   </a>
                 </Link>
               ))}
-            </div>
+            </div> */}
             {/* <div className={cn(styles['header-right'])}>
               <HostedByVercel />
               Created by the TuffyHacks Team

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -34,12 +34,13 @@ export const LEGAL_URL = process.env.NEXT_PUBLIC_PRIVACY_POLICY_URL;
 export const COPYRIGHT_HOLDER = process.env.NEXT_PUBLIC_COPYRIGHT_HOLDER;
 
 export const CODE_OF_CONDUCT = undefined;
-export const TWITCH_CHANNEL = 'tuffyhacks';
 export const EVENT_DATE = 'Sat Mar 27 2021 11:00:00 GMT-0700 (Pacific Daylight Time)';
+export const EMAIL = 'mailto: info@tuffyhacks.com';
 export const REPO = 'https://github.com/EthanThatOneKid/tuffyhacks.com';
 export const REGISTRATION = 'https://tinyurl.com/tuffyhacks2021-app';
 export const SPONSORSHIP = 'https://tinyurl.com/tuffyhacks-sponsorship';
 export const SAMPLE_TICKET_NUMBER = 1234;
+export const TWITCH_CHANNEL = 'tuffyhacks';
 export const NAVIGATION = [
   {
     name: 'About',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,6 +17,7 @@
 import { useRouter } from 'next/router';
 import { SkipNavContent } from '@reach/skip-nav';
 
+import Footer from '@components/footer';
 import Page from '@components/page';
 import ConfContent from '@components/index';
 import AboutSection from '@components/about-section';
@@ -28,7 +29,7 @@ export default function Conf() {
   const router = useRouter();
   const { query } = router;
   const meta = {
-    title: 'TuffyHacks 2021',
+    title: 'TuffyHacks',
     description: META_DESCRIPTION
   };
   const ticketNumber = query.ticketNumber?.toString();
@@ -46,9 +47,10 @@ export default function Conf() {
         defaultUserData={defaultUserData}
         defaultPageState={query.ticketNumber ? 'ticket' : 'registration'}
       />
-      <AboutSection />
+      {/* <AboutSection />
       <SponsorsSection />
-      <FaqSection />
+      <FaqSection /> */}
+      <Footer />
     </Page>
   );
 }

--- a/pages/meet-the-team.tsx
+++ b/pages/meet-the-team.tsx
@@ -7,7 +7,7 @@ import { META_DESCRIPTION } from '@lib/constants';
 
 export default function MeetTheTeam() {
   const meta = {
-    title: 'TuffyHacks 2021 | Team',
+    title: 'TuffyHacks | Team',
     description: META_DESCRIPTION
   };
 


### PR DESCRIPTION

## Description
I made different changes to gear our website for Phase 1 of the Hackathon Planning Cycle. 
Here are the changes:

- Simplified the layout to one screen
- Relabeled the apply organizer button to Stay up to date which links to the tuffyhacks IG
- The Sponsor 2022 was changed to Sponsor Us linking to our email
- I hid the nav bar links
- Added the footer to the main screen

**Current Look**
<img width="1336" alt="Screen Shot 2021-06-06 at 2 57 23 PM" src="https://user-images.githubusercontent.com/51276320/120941416-85ccec80-c6d7-11eb-8a97-73abdb3dd430.png">
Note: footer is hidden in the image, but if you scroll its at the bottom.